### PR TITLE
Add black formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Below are the supported linters and formatters that are configured to run with d
         + [`pylint`][pylint] => `require 'diagnosticls-nvim.linters.pylint'`
     + _Formatters_
         + [`autopep8`][autopep8] => `require 'diagnosticls-nvim.formatters.autopep8'`
+        + [`black`][black] => `require 'diagnosticls-nvim.formatters.black'`
 + Go
     + [`golangci_lint`][golangci_lint] => `require 'diagnosticls-nvim.linters.golangci_lint'`
     + [`revive`][revive] => `require 'diagnosticls-nvim.linters.revive'`
@@ -128,3 +129,4 @@ Coming Soon
 [vint]: https://github.com/Vimjas/vint
 [xo]: https://github.com/xojs/xo
 [autopep8]: https://github.com/hhatto/autopep8
+[black]: https://github.com/psf/black

--- a/lua/diagnosticls-nvim/formatters/black.lua
+++ b/lua/diagnosticls-nvim/formatters/black.lua
@@ -3,4 +3,9 @@ return {
   command = 'black',
   args = { '%filepath' },
   doesWriteToFile = true,
+  rootPatterns = {
+      '.git',
+      'pyproject.toml',
+      'setup.py',
+  },
 }


### PR DESCRIPTION
Was waiting for #3 to be completed, but it was taking a while. I think the requester was busy so I just forked his fork and completed it.

Added the configs for the [Black](https://github.com/psf/black) formatter for Python, and the appropriate updates to the readme.